### PR TITLE
Always compile OpenUSD in release mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,12 @@ repos:
     hooks:
       - id: beautysh
 
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.1-beta
+    hooks:
+      - id: hadolint-docker
+        args: [--ignore, SC1091, --ignore, DL3003, --ignore, DL3008]
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.6
     hooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "pxr"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "pxr_sys",
  "thiserror",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "pxr_build"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "regex",
  "which 5.0.0",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "pxr_sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "autocxx",
  "autocxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/AndrejOrsula/pxr_rs"
 rust-version = "1.70"
-version = "0.1.1"
+version = "0.1.2"
 
 [workspace.dependencies]
-pxr_build = { path = "pxr_build", version = "0.1.1" }
-pxr_sys = { path = "pxr_sys", version = "0.1.1" }
+pxr_build = { path = "pxr_build", version = "0.1.2" }
+pxr_sys = { path = "pxr_sys", version = "0.1.2" }
 
 autocxx = { version = "0.26" }
 autocxx-build = { version = "0.26" }

--- a/pxr_sys/build.rs
+++ b/pxr_sys/build.rs
@@ -450,13 +450,13 @@ mod vendored {
         #[cfg(feature = "monolithic_lib")]
         extra_args.push("--build-monolithic".to_string());
 
-        // Select debug or release build variant
-        #[cfg(debug_assertions)]
-        {
-            extra_args.push("--build-variant=debug".to_string()); // Alternative: --build-variant=relwithdebuginfo
-            extra_args.push("--prefer-safety-over-speed".to_string());
-        }
-        #[cfg(not(debug_assertions))]
+        // // Select debug or release build variant
+        // #[cfg(debug_assertions)]
+        // {
+        //     extra_args.push("--build-variant=debug".to_string()); // Alternative: --build-variant=relwithdebuginfo
+        //     extra_args.push("--prefer-safety-over-speed".to_string());
+        // }
+        // #[cfg(not(debug_assertions))]
         {
             extra_args.push("--build-variant=release".to_string());
             extra_args.push("--prefer-speed-over-safety".to_string());
@@ -558,9 +558,9 @@ mod vendored {
 
     fn determine_cache_path_openusd(version: &str) -> std::path::PathBuf {
         // Determine the name of the build variant
-        #[cfg(debug_assertions)]
-        const BUILD_VARIANT: &str = "_debug";
-        #[cfg(not(debug_assertions))]
+        // #[cfg(debug_assertions)]
+        // const BUILD_VARIANT: &str = "_debug";
+        // #[cfg(not(debug_assertions))]
         const BUILD_VARIANT: &str = "_release";
 
         // Determine if the build is monolithic


### PR DESCRIPTION
The reason for this is that debug symbols are too large (storage-wise) for CI runs.